### PR TITLE
Convert actionsimporter/pipelines/pipeline1 to GitHub Actions

### DIFF
--- a/.github/workflows/pipeline1.yml
+++ b/.github/workflows/pipeline1.yml
@@ -5,7 +5,9 @@ on:
     - main
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on:
+      - self-hosted
+      - linux-latest
     steps:
     - name: checkout
       uses: actions/checkout@v4.1.0


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/swapnetasupkar1908/actionsimporter/_build?definitionId=38) :tada:

## Manual steps

Perform the following steps to complete the migration:

### actionsimporter/pipelines/pipeline1
- [ ] Ensure a runner with the following labels exists: linux-latest